### PR TITLE
Fix install script

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,13 +1,7 @@
 import launch
 
-if not launch.is_installed("opencv-contrib-python"):
+if not launch.is_installed("cv2.ximgproc"):
     launch.run_pip(
         "install opencv-contrib-python",
         "requirements for Adverse Cleaner",
     )
-
-# if not launch.is_installed("opencv-contrib-python"):
-#     launch.run_pip(
-#         "install opencv-contrib-python --user",
-#         "requirements for Adverse Cleaner",
-#     )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -4,10 +4,18 @@ from PIL import Image
 from pathlib import Path
 import os
 
-from cv2.ximgproc import guidedFilter
+try:
+    from cv2.ximgproc import guidedFilter
+except ImportError as e:
+    print(f'''{e}
+=====================================================================
+Failed to import cv2.ximgproc Adverse Cleaner will not function
+You will need to install opencv-contrib-python manually
+Read Adverse Cleaner README.md for instructions
+https://github.com/p1atdev/stable-diffusion-webui-adverse-cleaner-tab
+=====================================================================''')
 
 import gradio as gr
-import launch
 from modules import script_callbacks
 
 
@@ -97,6 +105,24 @@ def clear_output():
 
 def on_ui_tabs():
     with gr.Blocks() as app:
+        try:
+            from cv2.ximgproc import guidedFilter
+        except ImportError:
+            gr.Markdown('''# Failed to import cv2.ximgproc Adverse Cleaner will not function
+You need to manually install `opencv-contrib-python` because the webui uses opencv-python, so the extension can't modify the opencv package while running.
+### instructions
+open the stable-diffusion-webui folder in terminal.
+```bash
+cd /path/to/stable-diffusion-webui
+```
+Activate venv,
+```bash
+./venv/Scripts/activate
+```
+Install `opencv-contrib-python`
+```
+pip install opencv-contrib-python
+```''')
         with gr.Tabs():
             with gr.TabItem(label="Single"):
                 with gr.Row ():  


### PR DESCRIPTION
fix `not launch.is_installed("opencv-contrib-python")`
`launch.is_installed("opencv-contrib-python")` will always be false
use `launch.is_installed("cv2.ximgproc")`
otherwise on every launch it will wasting time try to install opencv-contrib-python again

add install help message when failed to import `cv2.ximgproc`
in termainl and UI
screenshot
![image](https://github.com/p1atdev/stable-diffusion-webui-adverse-cleaner-tab/assets/40751091/c61dcabb-37e3-4ce1-a3c4-5593ccb69363)

---

additional business
hi I'm the maintainer of webui's extension index
if you wish to have this extension listed on webui's extension index please send a PR to https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions
